### PR TITLE
TweetFilter converting dates to correct format

### DIFF
--- a/src/models/payloads/TweetFilter.ts
+++ b/src/models/payloads/TweetFilter.ts
@@ -1,5 +1,5 @@
 // PACKAGE
-import { IsArray, IsBoolean, IsNumberString, IsString, IsOptional, IsDateString, validateSync } from 'class-validator';
+import { IsArray, IsBoolean, IsNumberString, IsString, IsOptional, IsDate, validateSync } from 'class-validator';
 
 // TYPES
 import { ITweetFilter } from '../../types/request/payloads/TweetFilter';
@@ -59,23 +59,15 @@ export class TweetFilter implements ITweetFilter {
 	@IsOptional()
 	mentions?: string[];
 
-	/** The date starting from which tweets are to be searched.
-	 *
-	 * @remarks
-	 * Must be in the format YYYY-MM-DD.
-	 */
+	/** The date starting from which tweets are to be searched. */
 	@IsOptional()
-	@IsDateString()
-	startDate?: string;
+	@IsDate()
+	startDate?: Date;
 
-	/** The date upto which tweets are to be searched.
-	 *
-	 * @remarks
-	 * Must be in the format YYYY-MM-DD.
-	 */
+	/** The date upto which tweets are to be searched. */
 	@IsOptional()
-	@IsDateString()
-	endDate?: string;
+	@IsDate()
+	endDate?: Date;
 
 	/** The id of the tweet, after which the tweets are to be searched. */
 	@IsNumberString()
@@ -132,13 +124,34 @@ export class TweetFilter implements ITweetFilter {
 				this.fromUsers ? `(${this.fromUsers.map((user) => `from:${user}`).join(' OR ')})` : '',
 				this.toUsers ? `(${this.toUsers.map((user) => `to:${user}`).join(' OR ')})` : '',
 				this.mentions ? `(${this.mentions.map((mention) => '@' + mention).join(' OR ')})` : '',
-				this.startDate ? `since:${this.startDate}` : '',
-				this.endDate ? `until:${this.endDate}` : '',
+				this.startDate ? `since:${TweetFilter.dateToTwitterString(this.startDate)}` : '',
+				this.endDate ? `until:${TweetFilter.dateToTwitterString(this.endDate)}` : '',
 				this.sinceId ? `since_id:${this.sinceId}` : '',
 				this.quoted ? `quoted_tweet_id:${this.quoted}` : '',
 			]
 				.filter((item) => item !== '()' && item !== '')
 				.join(' ') + (!this.links ? ' -this:links' : '')
 		);
+	}
+
+	/**
+	 * Convert Date object to Twitter string representation.
+	 * eg - 2023-06-23_11:21:06_UTC
+	 *
+	 * @param date The date object to convert.
+	 * @returns The Twitter string representation of the date.
+	 */
+	private static dateToTwitterString(date: Date): string {
+		const utc = new Date(
+			Date.UTC(
+				date.getUTCFullYear(),
+				date.getUTCMonth(),
+				date.getUTCDate(),
+				date.getUTCHours(),
+				date.getUTCMinutes(),
+				date.getUTCSeconds(),
+			),
+		);
+		return utc.toISOString().replace(/T/, '_').replace(/\..+/, '') + '_UTC';
 	}
 }

--- a/src/types/request/payloads/TweetFilter.ts
+++ b/src/types/request/payloads/TweetFilter.ts
@@ -20,10 +20,10 @@ export interface ITweetFilter {
 	mentions?: string[];
 
 	/** The date starting from which tweets are to be searched. */
-	startDate?: string;
+	startDate?: Date;
 
 	/** The date upto which tweets are to be searched. */
-	endDate?: string;
+	endDate?: Date;
 
 	/** The id of the tweet, after which the tweets are to be searched. */
 	sinceId?: string;


### PR DESCRIPTION
The `startDate` and `endDate` functionality was not working and I was receiving empty results from `getTweets` when supplying dates. I've updated `TweetFilter` to accept `Date` type arguments and they are converted to the correct string format to send to Twitter ie 2023-06-23_11:21:06_UTC.

Hopefully this change is acceptable, but I understand it does break existing usage.

It will require an update to `TweetResolver` in Rettiwt-API too.