### PR TITLE
Add maxId as a TweetFilter property when searching tweets

### DIFF
--- a/src/models/payloads/TweetFilter.ts
+++ b/src/models/payloads/TweetFilter.ts
@@ -84,6 +84,16 @@ export class TweetFilter implements ITweetFilter {
 	public sinceId?: string;
 
 	/**
+	 * The id of the tweet, before which the tweets are to be searched.
+	 *
+	 * @remarks
+	 * Must be a numeric string.
+	 */
+	@IsNumberString()
+	@IsOptional()
+	public maxId?: string;
+
+	/**
 	 * The id of the tweet which is quoted in the tweets to search.
 	 *
 	 * @remarks
@@ -121,6 +131,7 @@ export class TweetFilter implements ITweetFilter {
 		this.mentions = filter.mentions;
 		this.quoted = filter.quoted;
 		this.sinceId = filter.sinceId;
+		this.maxId = filter.maxId;
 		this.startDate = filter.startDate;
 		this.toUsers = filter.toUsers;
 		this.words = filter.words;
@@ -150,6 +161,7 @@ export class TweetFilter implements ITweetFilter {
 				this.startDate ? `since:${TweetFilter.dateToTwitterString(this.startDate)}` : '',
 				this.endDate ? `until:${TweetFilter.dateToTwitterString(this.endDate)}` : '',
 				this.sinceId ? `since_id:${this.sinceId}` : '',
+				this.maxId ? `max_id:${this.maxId}` : '',
 				this.quoted ? `quoted_tweet_id:${this.quoted}` : '',
 			]
 				.filter((item) => item !== '()' && item !== '')

--- a/src/types/request/payloads/TweetFilter.ts
+++ b/src/types/request/payloads/TweetFilter.ts
@@ -30,6 +30,9 @@ export interface ITweetFilter {
 	/** The id of the tweet, after which the tweets are to be searched. */
 	sinceId?: string;
 
+	/** The id of the tweet, before which the tweets are to be searched. */
+	maxId?: string;
+
 	/** The id of the tweet which is quoted in the tweets to search. */
 	quoted?: string;
 


### PR DESCRIPTION
I added a "maxId" field in the TweetFilter definition to allow for searching for tweets *before* a given tweet ID. IIRC Rettiwt 1.x used to have both since_id and max_id as available filter fields, so I'm not sure why one stayed and the other didn't. 

Regardless, the backend twitter API Rettiwt calls still definitely accepts max_id as a param, so it was easy to add a maxId entry. I used the same type def/description/etc as sinceId (replacing "after" with "before") and gave it a few tests locally; seems to be WAI.

