### PR TITLE
[#98] Add support for tweets/posts with Spaces

### DIFF
--- a/src/enums/Resources.ts
+++ b/src/enums/Resources.ts
@@ -31,4 +31,5 @@ export enum EResourceType {
 	USER_TWEETS = '/i/api/graphql/H8OOoI-5ZE4NxgRr8lfyWg/UserTweets',
 	USER_TWEETS_AND_REPLIES = '/i/api/graphql/GJuqLMoVxFZOvy8Oqec_9Q/UserTweetsAndReplies',
 	MEDIA_UPLOAD = '/i/media/upload.json',
+	SPACE_DETAILS = "i/api/graphql/s2tz6GAie-O1tdZx873PLA/AudioSpaceById",
 }

--- a/src/models/args/DataArgs.ts
+++ b/src/models/args/DataArgs.ts
@@ -1,5 +1,5 @@
 // PACKAGES
-import { IsArray, IsNotEmpty, IsNumberString, IsOptional, Max, MaxLength, validateSync } from 'class-validator';
+import { IsArray, IsNotEmpty, IsNumberString, IsOptional, IsString, Max, MaxLength, validateSync } from 'class-validator';
 
 // ENUMS
 import { EResourceType } from '../../enums/Resources';
@@ -46,6 +46,7 @@ export class DataArgs implements IDataArgs {
 			EResourceType.USER_LIKES,
 			EResourceType.USER_TWEETS,
 			EResourceType.USER_TWEETS_AND_REPLIES,
+			EResourceType.SPACE_DETAILS
 		],
 	})
 	@IsNumberString(undefined, {
@@ -65,6 +66,12 @@ export class DataArgs implements IDataArgs {
 			EResourceType.USER_TWEETS_AND_REPLIES,
 		],
 	})
+	@IsString({
+		groups: [
+			EResourceType.SPACE_DETAILS
+		],
+	})
+
 	public id?: string;
 
 	/**
@@ -115,6 +122,14 @@ export class DataArgs implements IDataArgs {
 	public tweetText?: string;
 
 	/**
+	 * @remarks
+	 * - May be used for {@link EResourceType.SPACE_DETAILS} resource type.
+	 */
+	public withReplays?: boolean;
+	public isMetatagsQuery?: boolean;
+	public withListeners?: boolean;
+
+	/**
 	 * Initializes a new DataArgs object using the given arguments.
 	 *
 	 * @param resourceType - The type of resource that is requested.
@@ -134,9 +149,17 @@ export class DataArgs implements IDataArgs {
 			this.filter = new TweetFilter(args.filter);
 		}
 
+		/**
+		 * Initializing withReplays, isMetatagsQuery and withListeners only if resource type is AUDIO_SPACE
+		 */
+		if (resourceType == EResourceType.SPACE_DETAILS) {
+			this.withReplays = args.withReplays ?? false;
+			this.isMetatagsQuery = args.isMetatagsQuery ?? false;
+			this.withListeners = args.withListeners ?? false;
+		}
+
 		// Validating this object
 		const validationResult = validateSync(this, { groups: [resourceType] });
-
 		// If valiation error occured
 		if (validationResult.length) {
 			throw new DataValidationError(validationResult);

--- a/src/models/payloads/Features.ts
+++ b/src/models/payloads/Features.ts
@@ -1,5 +1,6 @@
 // TYPES
 import { IFeatures } from '../../types/request/payloads/Features';
+import { EResourceType } from '../../enums/Resources';
 
 /**
  * Parameters for customizing the raw response, that must be sent as a URL-encoded, stringified-JSON.
@@ -33,6 +34,12 @@ export class Features implements IFeatures {
 	public hidden_profile_subscriptions_enabled = false;
 	public subscriptions_verification_info_verified_since_enabled = true;
 	public highlights_tweets_tab_ui_enabled = true;
+
+	// Features related to Spaces
+	public spaces_2022_h2_spaces_communities?: boolean;
+	public spaces_2022_h2_clipping?: boolean;
+	public c9s_tweet_anatomy_moderator_badge_enabled?: boolean;
+	public rweb_video_timestamps_enabled?: boolean;
 	/* eslint-enable @typescript-eslint/naming-convention */
 
 	/**
@@ -42,5 +49,14 @@ export class Features implements IFeatures {
 	 */
 	public toString(): string {
 		return JSON.stringify(this);
+	}
+
+	public constructor(resourceType: EResourceType) {
+		if (resourceType == EResourceType.SPACE_DETAILS) {
+			this.spaces_2022_h2_spaces_communities = true;
+			this.spaces_2022_h2_clipping = true;
+			this.c9s_tweet_anatomy_moderator_badge_enabled = true;
+			this.rweb_video_timestamps_enabled = true;
+		}
 	}
 }

--- a/src/models/payloads/Variables.ts
+++ b/src/models/payloads/Variables.ts
@@ -29,6 +29,12 @@ export class Variables implements IVariables {
 	public includePromotedContent: boolean = false;
 	public withVoice: boolean = false;
 	public withCommunity: boolean = false;
+
+	// Variables related to Spaces
+	public id?: string;
+	public withReplays?: boolean;
+	public isMetatagsQuery?: boolean;
+	public withListeners?: boolean;
 	/* eslint-enable @typescript-eslint/naming-convention */
 
 	/**
@@ -65,6 +71,11 @@ export class Variables implements IVariables {
 			this.screen_name = args.id;
 		} else if (resourceType == EResourceType.USER_DETAILS_BY_ID) {
 			this.userId = args.id;
+		} else if (resourceType == EResourceType.SPACE_DETAILS) {
+			this.id = args.id;
+			this.isMetatagsQuery = args.isMetatagsQuery;
+			this.withReplays = args.withReplays;
+			this.withListeners = args.withListeners;
 		} else if (
 			resourceType == EResourceType.USER_FOLLOWERS ||
 			resourceType == EResourceType.USER_FOLLOWING ||

--- a/src/types/request/args/DataArgs.ts
+++ b/src/types/request/args/DataArgs.ts
@@ -25,4 +25,9 @@ export interface IDataArgs {
 
 	/** The text for the tweet to be created. */
 	tweetText?: string;
+
+	/** Data Args used for Spaces */
+	withReplays?: boolean;
+	isMetatagsQuery?: boolean;
+	withListeners?: boolean;
 }

--- a/src/types/request/payloads/Features.ts
+++ b/src/types/request/payloads/Features.ts
@@ -30,6 +30,12 @@ export interface IFeatures {
 	hidden_profile_subscriptions_enabled: boolean;
 	subscriptions_verification_info_verified_since_enabled: boolean;
 	highlights_tweets_tab_ui_enabled: boolean;
+
+	// Features related to Spaces
+	spaces_2022_h2_spaces_communities?: boolean;
+	spaces_2022_h2_clipping?: boolean;
+	c9s_tweet_anatomy_moderator_badge_enabled?: boolean;
+	rweb_video_timestamps_enabled?: boolean;
 	/* eslint-enable @typescript-eslint/naming-convention */
 
 	/** @returns The string representation of 'this' data. */

--- a/src/types/request/payloads/Variables.ts
+++ b/src/types/request/payloads/Variables.ts
@@ -19,6 +19,11 @@ export interface IVariables {
 	includePromotedContent: boolean;
 	withVoice: boolean;
 	withCommunity: boolean;
+
+	// Variables related to Spaces
+	withReplays?: boolean;
+	isMetatagsQuery?: boolean;
+	withListeners?: boolean;
 	/* eslint-enable @typescript-eslint/naming-convention */
 
 	/** @returns The string representation of 'this' data. */


### PR DESCRIPTION
# Summary

## Types
* Add `SPACE_DETAILS` entry with API endpoint to `EResourceType` enum.
* Add properties related to Spaces to `Features` and `Variables` interfaces
* Add Spaces-related properties to `DataArgs` interface

## Implementations
* Add handling of Spaces-related features and variables in `Features` and `Variables` models.
* Add handling of Spaces-related args in `DataArgs` model.

