### PR TITLE
Added request configuration for creating reply to a Tweet

### DIFF
--- a/src/models/args/PostArgs.ts
+++ b/src/models/args/PostArgs.ts
@@ -79,10 +79,6 @@ export class TweetArgs {
 	@MaxLength(280)
 	public text: string;
 
-	@IsOptional()
-	@IsNumberString()
-	public replyTo?: string;
-
 	/**
 	 * The list of media to be uploaded.
 	 *
@@ -97,13 +93,18 @@ export class TweetArgs {
 	@IsObject({ each: true })
 	public media?: MediaArgs[];
 
+	/** The id of the Tweet to which the given Tweet must be a reply. */
+	@IsOptional()
+	@IsNumberString()
+	public replyTo?: string;
+
 	/**
 	 * @param args - The additional user-defined arguments for posting the resource.
 	 */
 	public constructor(args: TweetArgs) {
 		this.text = args.text;
-		this.replyTo = args.replyTo;
 		this.media = args.media ? args.media.map((item) => new MediaArgs(item)) : undefined;
+		this.replyTo = args.replyTo;
 
 		// Validating this object
 		const validationResult = validateSync(this);

--- a/src/models/args/PostArgs.ts
+++ b/src/models/args/PostArgs.ts
@@ -79,6 +79,10 @@ export class TweetArgs {
 	@MaxLength(280)
 	public text: string;
 
+	@IsOptional()
+	@IsNumberString()
+	public replyTo?: string;
+
 	/**
 	 * The list of media to be uploaded.
 	 *
@@ -98,6 +102,7 @@ export class TweetArgs {
 	 */
 	public constructor(args: TweetArgs) {
 		this.text = args.text;
+		this.replyTo = args.replyTo;
 		this.media = args.media ? args.media.map((item) => new MediaArgs(item)) : undefined;
 
 		// Validating this object

--- a/src/models/payloads/Variables.ts
+++ b/src/models/payloads/Variables.ts
@@ -23,6 +23,7 @@ export class Variables {
 	public controller_data?: string;
 	public rawQuery?: string;
 	public tweet_text?: string;
+	public reply?: ReplyVariable;
 	public media?: MediaVariable;
 	public product?: string;
 	public includePromotedContent?: boolean;
@@ -101,13 +102,33 @@ export class Variables {
 }
 
 /**
+ * Reply specific details to be sent in payload.
+ *
+ * @public
+ */
+export class ReplyVariable {
+	/* eslint-disable @typescript-eslint/naming-convention */
+	public in_reply_to_tweet_id: string;
+	public exclude_reply_user_ids: string[];
+	/* eslint-enable @typescript-eslint/naming-convention */
+
+	/**
+	 * @param replyTo - The id of the Tweet to which this Tweet is a reply.
+	 */
+	public constructor(replyTo: string) {
+		this.in_reply_to_tweet_id = replyTo;
+		this.exclude_reply_user_ids = [];
+	}
+}
+
+/**
  * Media to be sent as payload.
  *
  * @public
  */
 export class MediaVariable {
 	/* eslint-disable @typescript-eslint/naming-convention */
-	public media_entities: MediaVariableEntity[];
+	public media_entities: MediaEntityVariable[];
 	public possibly_sensitive: boolean;
 	/* eslint-enable @typescript-eslint/naming-convention */
 
@@ -115,7 +136,7 @@ export class MediaVariable {
 	 * @param media - The list of MediaArgs objects specifying the media items to be sent in the Tweet.
 	 */
 	public constructor(media: MediaArgs[]) {
-		this.media_entities = media.map((item) => new MediaVariableEntity(item));
+		this.media_entities = media.map((item) => new MediaEntityVariable(item));
 		this.possibly_sensitive = false;
 	}
 }
@@ -125,7 +146,7 @@ export class MediaVariable {
  *
  * @public
  */
-export class MediaVariableEntity {
+export class MediaEntityVariable {
 	/* eslint-disable @typescript-eslint/naming-convention */
 	public media_id: string;
 	public tagged_users: string[];

--- a/src/models/payloads/Variables.ts
+++ b/src/models/payloads/Variables.ts
@@ -23,8 +23,8 @@ export class Variables {
 	public controller_data?: string;
 	public rawQuery?: string;
 	public tweet_text?: string;
-	public reply?: ReplyVariable;
 	public media?: MediaVariable;
+	public reply?: ReplyVariable;
 	public product?: string;
 	public includePromotedContent?: boolean;
 	public isMetatagsQuery?: boolean;
@@ -43,6 +43,7 @@ export class Variables {
 		if (resourceType == EResourceType.CREATE_TWEET) {
 			this.tweet_text = args.tweet?.text;
 			this.media = args.tweet?.media ? new MediaVariable(args.tweet.media) : undefined;
+			this.reply = args.tweet?.replyTo ? new ReplyVariable(args.tweet.replyTo) : undefined;
 		} else if (resourceType == EResourceType.CREATE_RETWEET || resourceType == EResourceType.FAVORITE_TWEET) {
 			this.tweet_id = args.id;
 		} else if (resourceType == EResourceType.LIST_DETAILS) {
@@ -102,26 +103,6 @@ export class Variables {
 }
 
 /**
- * Reply specific details to be sent in payload.
- *
- * @public
- */
-export class ReplyVariable {
-	/* eslint-disable @typescript-eslint/naming-convention */
-	public in_reply_to_tweet_id: string;
-	public exclude_reply_user_ids: string[];
-	/* eslint-enable @typescript-eslint/naming-convention */
-
-	/**
-	 * @param replyTo - The id of the Tweet to which this Tweet is a reply.
-	 */
-	public constructor(replyTo: string) {
-		this.in_reply_to_tweet_id = replyTo;
-		this.exclude_reply_user_ids = [];
-	}
-}
-
-/**
  * Media to be sent as payload.
  *
  * @public
@@ -158,5 +139,25 @@ export class MediaEntityVariable {
 	public constructor(media: MediaArgs) {
 		this.media_id = media.id;
 		this.tagged_users = media.tags ?? [];
+	}
+}
+
+/**
+ * Reply specific details to be sent in payload.
+ *
+ * @public
+ */
+export class ReplyVariable {
+	/* eslint-disable @typescript-eslint/naming-convention */
+	public in_reply_to_tweet_id: string;
+	public exclude_reply_user_ids: string[];
+	/* eslint-enable @typescript-eslint/naming-convention */
+
+	/**
+	 * @param replyTo - The id of the Tweet to which this Tweet is a reply.
+	 */
+	public constructor(replyTo: string) {
+		this.in_reply_to_tweet_id = replyTo;
+		this.exclude_reply_user_ids = [];
 	}
 }


### PR DESCRIPTION
A reply configuration can be created using the same method as for creating a tweet, by specifying an additional parameter `replyTo` which contains the ID of the Tweet to which the given Tweet is to be reply, as follows:

```
const request = new Request(EResourceType.CREATE_TWEET, {
    tweet: {
        text: "<reply_text>",
        replyTo: "<id_of_target_tweet>"
    }
};
```
