### PR TITLE
Added request config for quoting a Tweet

### DIFF
--- a/src/models/args/PostArgs.ts
+++ b/src/models/args/PostArgs.ts
@@ -79,6 +79,11 @@ export class TweetArgs {
 	@MaxLength(280)
 	public text: string;
 
+	/** The id of the tweet to quote. */
+	@IsOptional()
+	@IsNumberString()
+	public quote?: string;
+
 	/**
 	 * The list of media to be uploaded.
 	 *
@@ -103,6 +108,7 @@ export class TweetArgs {
 	 */
 	public constructor(args: TweetArgs) {
 		this.text = args.text;
+		this.quote = args.quote;
 		this.media = args.media ? args.media.map((item) => new MediaArgs(item)) : undefined;
 		this.replyTo = args.replyTo;
 

--- a/src/models/payloads/Variables.ts
+++ b/src/models/payloads/Variables.ts
@@ -23,6 +23,7 @@ export class Variables {
 	public controller_data?: string;
 	public rawQuery?: string;
 	public tweet_text?: string;
+	public attachment_url?: string;
 	public media?: MediaVariable;
 	public reply?: ReplyVariable;
 	public product?: string;
@@ -42,6 +43,7 @@ export class Variables {
 		// Conditionally initializing variables
 		if (resourceType == EResourceType.CREATE_TWEET) {
 			this.tweet_text = args.tweet?.text;
+			this.attachment_url = args.tweet?.quote ? `https://twitter.com/i/status/${args.tweet.quote}` : undefined;
 			this.media = args.tweet?.media ? new MediaVariable(args.tweet.media) : undefined;
 			this.reply = args.tweet?.replyTo ? new ReplyVariable(args.tweet.replyTo) : undefined;
 		} else if (resourceType == EResourceType.CREATE_RETWEET || resourceType == EResourceType.FAVORITE_TWEET) {


### PR DESCRIPTION
To quote a tweet, use an optional parameter `quote` which takes the id of the tweet to quote, while creating a tweet, as follows:

```js
import { Rettiwt } from 'rettiwt-core`;

const request = new Request(CREATE_TWEET, { tweet: { text: "Hello!", quote: "123456789" } });
```