### PR TITLE
Updated raw user details type

### DIFF
--- a/src/types/user/Details.ts
+++ b/src/types/user/Details.ts
@@ -33,7 +33,37 @@ export interface Result {
 	is_profile_translatable: boolean;
 }
 
-export interface AffiliatesHighlightedLabel {}
+export interface AffiliatesHighlightedLabel {
+	label: {
+		badge: {
+			url: string;
+		}
+		description: string;
+		longDescription: {
+			text: string;
+			entities: AffiliatesHighlightedLabelEntity[]
+		}
+	}
+}
+
+export interface AffiliatesHighlightedLabelEntity {
+	fromIndex: number; 
+	toIndex: number;
+	ref: AffiliatesHighlightedMention;
+}
+
+export interface AffiliatesHighlightedMention {
+	type: string;
+	screen_name; string;
+	mention_results: {
+		result: {
+			__typename: "User";
+			legacy: {
+				screen_name: string;
+			}
+			rest_id: string;
+	}
+}
 
 export interface Legacy {
 	blocked_by: boolean;


### PR DESCRIPTION
Hi @Rishikant181 awesome work on reverse engineering Twitter API!

I found some bug during retrieving .details from a few automated twitter accounts, you can check it on your own for example for accounts `aixbt_agent` or `babysentio`.

findByFilter function creating 2 Users models, which is incorrect

https://github.com/Rishikant181/Rettiwt-API/blob/b953153b40e76034b78ff2f2708d3aa622431d32/src/helper/JsonUtils.ts#L34-L36

![image](https://github.com/user-attachments/assets/9c15718f-fdba-4982-80a9-207b454a1d62)

And mentions also contains `__typename` that intersect with original passed key to `findByFilter` function

![image](https://github.com/user-attachments/assets/956ba967-2648-4a41-b51f-e5c9d57e51ba)

And it break the code.

So I decided to start with changing model in `Rettiwt-Core`, however it seems we have to add exception/additional conditional to `findByFilter`, so we are not creating 2 models, but only 1.

Since we want to fetch only 1 twitter account rather than 2.

What do you think about it? 

I'm thinking about adding just hardcode piece. to `findByFilter` if type `TimelineRichTextMention` than return it, without going more deeply. It's just a raw ideas.

I'll be glad for any feedback